### PR TITLE
Remove explicit installation of brew-cask

### DIFF
--- a/bin/setup.bash
+++ b/bin/setup.bash
@@ -72,7 +72,6 @@ install_packages() {
 		packer
 	)
 
-	brew install caskroom/cask/brew-cask
 	brew update
 
 	brew cask install "${CASK_APPS[@]}"


### PR DESCRIPTION
Hey @d ,
I tried setting up a fresh laptop and the script was failing on the Homebrew Cask install. It's now part of Homebrew by default so this step is no longer needed https://github.com/caskroom/homebrew-cask for more information.
